### PR TITLE
Feature 1: fix: support cases where a scrollbar is present when drawing

### DIFF
--- a/client/src/components/interact/Draggable.tsx
+++ b/client/src/components/interact/Draggable.tsx
@@ -46,7 +46,7 @@ export default function Draggable({
 
     const interactable = interact(elRef.current)
       .draggable({
-        onstart: ({ x0, y0 }: Interact.InteractEvent<'drag', 'start'>) => {
+        onstart: ({ clientX, clientY }: Interact.InteractEvent<'drag', 'start'>) => {
           if (!elRef.current) {
             console.warn('Draggable: elRef is null!')
             return
@@ -54,8 +54,8 @@ export default function Draggable({
 
           const rect = elRef.current.getBoundingClientRect()
           const point = {
-            x: x0 - rect.x,
-            y: y0 - rect.y,
+            x: clientX - rect.x,
+            y: clientY - rect.y,
           }
 
           onDrag({

--- a/client/src/components/interact/Draggable.tsx
+++ b/client/src/components/interact/Draggable.tsx
@@ -46,7 +46,7 @@ export default function Draggable({
 
     const interactable = interact(elRef.current)
       .draggable({
-        onstart: ({ clientX, clientY }: Interact.InteractEvent<'drag', 'start'>) => {
+        onstart: ({ clientX0, clientY0 }: Interact.InteractEvent<'drag', 'start'>) => {
           if (!elRef.current) {
             console.warn('Draggable: elRef is null!')
             return
@@ -54,8 +54,8 @@ export default function Draggable({
 
           const rect = elRef.current.getBoundingClientRect()
           const point = {
-            x: clientX - rect.x,
-            y: clientY - rect.y,
+            x: clientX0 - rect.x,
+            y: clientY0 - rect.y,
           }
 
           onDrag({


### PR DESCRIPTION
Rep steps:

1. Host/join a room while the browser window is maximized
2. Resize the window to 50% of the screen's width
3. Resize the window to 50% of the screen's height
4. Scroll down to the end of the page
5. Try to draw something

Expected: Normal drawing behavior. The path will appear where your cursor is at.
Actual: Path does not appear where the cursor is at. The disjoint path being rendered on screen follows the motion of the cursor though.